### PR TITLE
Add safe edit planning slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,12 @@ We **never blindly rewrite files**.
 
 All edits are:
 
+- planned in the daemon
 - anchored
 - validated
 - diffed before apply
+
+The current implementation intentionally supports a small deterministic slice instead of pretending the planner is finished.
 
 #### 2. Daemon-first architecture
 
@@ -181,7 +184,7 @@ The extension is just:
 #### 4. Streaming everything
 
 - voice → streaming STT
-- edits → incremental planning
+- edits → incremental planning (currently rule-based for a small safe slice)
 - UI → live feedback
 
 ---
@@ -192,7 +195,7 @@ The extension is just:
 - ✅ Daemon spawns
 - ✅ Cross-platform daemon build
 - 🚧 JSON-RPC transport (next)
-- 🚧 Edit engine wiring
+- 🚧 Rich edit engine wiring beyond the initial safe slice
 - 🚧 Voice pipeline
 
 ---
@@ -228,7 +231,7 @@ Vocode: Apply Edit
 Vocode: Run Command
 ```
 
-(Currently stubbed)
+Supported today: deterministic single-file edits for `insert statement "..." inside current function`, `replace block after "..." before "..." with "..."`, and `append import "..." if missing`. The daemon now returns structured failures when it cannot produce a safe edit.
 
 ---
 

--- a/apps/daemon/internal/agent/intent.go
+++ b/apps/daemon/internal/agent/intent.go
@@ -1,1 +1,30 @@
 package agent
+
+// EditIntentKind identifies the small deterministic edit slice the daemon can
+// safely map today.
+type EditIntentKind string
+
+const (
+	EditIntentInsertStatementInCurrentFunction EditIntentKind = "insert_statement_in_current_function"
+	EditIntentReplaceAnchoredBlock             EditIntentKind = "replace_anchored_block"
+	EditIntentAppendImportIfMissing            EditIntentKind = "append_import_if_missing"
+)
+
+// EditIntent is the instruction shape produced by the agent planner.
+//
+// Supported v1 intents:
+//   - insert statement inside current function
+//   - replace a selected/anchored block
+//   - append import if missing
+//
+// The planner is intentionally rule-based so unsupported or ambiguous requests
+// fail closed instead of guessing.
+type EditIntent struct {
+	Kind EditIntentKind
+
+	Statement string
+	Before    string
+	After     string
+	NewText   string
+	Import    string
+}

--- a/apps/daemon/internal/agent/models.go
+++ b/apps/daemon/internal/agent/models.go
@@ -1,1 +1,12 @@
 package agent
+
+import protocol "vocoding.net/vocode/v2/packages/protocol/go"
+
+type EditPlan struct {
+	Intent EditIntent
+}
+
+type EditPlanResult struct {
+	Plan    *EditPlan
+	Failure *protocol.EditFailure
+}

--- a/apps/daemon/internal/agent/planner.go
+++ b/apps/daemon/internal/agent/planner.go
@@ -1,1 +1,101 @@
 package agent
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	protocol "vocoding.net/vocode/v2/packages/protocol/go"
+)
+
+var (
+	quotedValuePattern = regexp.MustCompile("(?s)(?:\"([^\"]+)\"|`([^`]+)`)")
+
+	insertStatementPattern = regexp.MustCompile(
+		`(?is)^insert(?:\s+statement)?\s+(?:\"([^\"]+)\"|` + "`([^`]+)`" + `)\s+inside\s+current\s+function$`,
+	)
+	replaceAnchoredBlockPattern = regexp.MustCompile(
+		`(?is)^replace\s+block\s+after\s+(?:\"([^\"]+)\"|` + "`([^`]+)`" + `)\s+before\s+(?:\"([^\"]+)\"|` + "`([^`]+)`" + `)\s+with\s+(?:\"([^\"]+)\"|` + "`([^`]+)`" + `)$`,
+	)
+	appendImportPattern = regexp.MustCompile(
+		`(?is)^(?:append|add)\s+import\s+(?:\"([^\"]+)\"|` + "`([^`]+)`" + `)\s+if\s+missing$`,
+	)
+)
+
+type Planner struct{}
+
+func NewPlanner() *Planner {
+	return &Planner{}
+}
+
+func (p *Planner) Plan(params protocol.EditApplyParams) EditPlanResult {
+	instruction := strings.TrimSpace(params.Instruction)
+	if instruction == "" {
+		return EditPlanResult{Failure: failure("unsupported_instruction", "Instruction was empty.")}
+	}
+
+	if matches := insertStatementPattern.FindStringSubmatch(instruction); matches != nil {
+		statement := firstNonEmpty(matches[1], matches[2])
+		return EditPlanResult{Plan: &EditPlan{Intent: EditIntent{
+			Kind:      EditIntentInsertStatementInCurrentFunction,
+			Statement: strings.TrimSpace(statement),
+		}}}
+	}
+
+	if matches := replaceAnchoredBlockPattern.FindStringSubmatch(instruction); matches != nil {
+		before := firstNonEmpty(matches[1], matches[2])
+		after := firstNonEmpty(matches[3], matches[4])
+		newText := firstNonEmpty(matches[5], matches[6])
+		return EditPlanResult{Plan: &EditPlan{Intent: EditIntent{
+			Kind:    EditIntentReplaceAnchoredBlock,
+			Before:  before,
+			After:   after,
+			NewText: newText,
+		}}}
+	}
+
+	if matches := appendImportPattern.FindStringSubmatch(instruction); matches != nil {
+		statement := strings.TrimSpace(firstNonEmpty(matches[1], matches[2]))
+		if !strings.HasPrefix(statement, "import ") {
+			return EditPlanResult{Failure: failure(
+				"unsupported_instruction",
+				fmt.Sprintf("Import instruction must include a full import statement, got %q.", statement),
+			)}
+		}
+		return EditPlanResult{Plan: &EditPlan{Intent: EditIntent{
+			Kind:   EditIntentAppendImportIfMissing,
+			Import: statement,
+		}}}
+	}
+
+	return EditPlanResult{Failure: failure(
+		"unsupported_instruction",
+		"Supported instructions: insert statement \"...\" inside current function; replace block after \"...\" before \"...\" with \"...\"; append import \"...\" if missing.",
+	)}
+}
+
+func ExtractQuotedValues(input string) []string {
+	matches := quotedValuePattern.FindAllStringSubmatch(input, -1)
+	values := make([]string, 0, len(matches))
+	for _, match := range matches {
+		value := firstNonEmpty(match[1], match[2])
+		if strings.TrimSpace(value) == "" {
+			continue
+		}
+		values = append(values, value)
+	}
+	return values
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func failure(code string, message string) *protocol.EditFailure {
+	return &protocol.EditFailure{Code: code, Message: message}
+}

--- a/apps/daemon/internal/agent/service.go
+++ b/apps/daemon/internal/agent/service.go
@@ -1,1 +1,15 @@
 package agent
+
+import protocol "vocoding.net/vocode/v2/packages/protocol/go"
+
+type Service struct {
+	planner *Planner
+}
+
+func NewService() *Service {
+	return &Service{planner: NewPlanner()}
+}
+
+func (s *Service) PlanEdit(params protocol.EditApplyParams) EditPlanResult {
+	return s.planner.Plan(params)
+}

--- a/apps/daemon/internal/app/app.go
+++ b/apps/daemon/internal/app/app.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"log"
 
+	"vocoding.net/vocode/v2/apps/daemon/internal/agent"
 	"vocoding.net/vocode/v2/apps/daemon/internal/edits"
 	"vocoding.net/vocode/v2/apps/daemon/internal/rpc"
 )
@@ -21,7 +22,8 @@ type App struct {
 }
 
 func New(opts Options) (*App, error) {
-	editService := edits.NewService()
+	agentService := agent.NewService()
+	editService := edits.NewService(agentService)
 
 	router := rpc.NewRouter(opts.Logger)
 	for _, def := range rpc.BuildHandlers(editService) {

--- a/apps/daemon/internal/edits/anchors.go
+++ b/apps/daemon/internal/edits/anchors.go
@@ -1,1 +1,141 @@
 package edits
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	protocol "vocoding.net/vocode/v2/packages/protocol/go"
+)
+
+type lineBlock struct {
+	beforeLine  string
+	afterAnchor string
+	between     string
+	indent      string
+}
+
+var functionStartPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^\s*func\b`),
+	regexp.MustCompile(`^\s*(?:export\s+)?(?:async\s+)?function\b`),
+	regexp.MustCompile(`^\s*(?:export\s+)?(?:const|let|var)\s+\w+\s*=\s*(?:async\s*)?\([^)]*\)\s*=>\s*\{`),
+	regexp.MustCompile(`^\s*(?:public\s+|private\s+|protected\s+|static\s+|async\s+)*\w+\([^)]*\)\s*\{`),
+}
+
+func findUniqueAnchoredRange(fileText string, before string, after string) (int, int, *protocol.EditFailure) {
+	_, beforeEnd, beforeFailure := findUniqueOccurrence(fileText, before, 0, "before")
+	if beforeFailure != nil {
+		return 0, 0, beforeFailure
+	}
+
+	afterStart, _, afterFailure := findUniqueOccurrence(fileText, after, beforeEnd, "after")
+	if afterFailure != nil {
+		return 0, 0, afterFailure
+	}
+
+	if afterStart < beforeEnd {
+		return 0, 0, editFailure("validation_failed", "Anchor order was invalid.")
+	}
+
+	return beforeEnd, afterStart, nil
+}
+
+func findUniqueOccurrence(fileText string, needle string, start int, label string) (int, int, *protocol.EditFailure) {
+	if needle == "" {
+		return 0, 0, editFailure("missing_anchor", fmt.Sprintf("The %s anchor was empty.", label))
+	}
+
+	index := strings.Index(fileText[start:], needle)
+	if index == -1 {
+		return 0, 0, editFailure("missing_anchor", fmt.Sprintf("Could not find %s anchor %q.", label, needle))
+	}
+
+	absoluteStart := start + index
+	nextIndex := strings.Index(fileText[absoluteStart+1:], needle)
+	if nextIndex != -1 {
+		return 0, 0, editFailure("ambiguous_target", fmt.Sprintf("The %s anchor %q matched multiple locations.", label, needle))
+	}
+
+	return absoluteStart, absoluteStart + len(needle), nil
+}
+
+func findSingleFunctionBlock(fileText string) (*lineBlock, *protocol.EditFailure) {
+	lines := strings.Split(fileText, "\n")
+	candidates := make([]lineBlock, 0, 1)
+
+	for lineIndex, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !isFunctionStart(trimmed) || !strings.Contains(line, "{") {
+			continue
+		}
+
+		closeIndex, ok := findMatchingBraceLine(lines, lineIndex)
+		if !ok || closeIndex <= lineIndex {
+			continue
+		}
+
+		between := "\n"
+		if closeIndex > lineIndex+1 {
+			between += strings.Join(lines[lineIndex+1:closeIndex], "\n")
+			between += "\n"
+		}
+
+		candidates = append(candidates, lineBlock{
+			beforeLine:  line,
+			afterAnchor: strings.Join(lines[closeIndex:], "\n"),
+			between:     between,
+			indent:      indentForBlock(line),
+		})
+	}
+
+	switch len(candidates) {
+	case 0:
+		return nil, editFailure("missing_anchor", "Could not find a supported current function in the active file.")
+	case 1:
+		return &candidates[0], nil
+	default:
+		return nil, editFailure("ambiguous_target", "The active file contains multiple candidate functions; current function was ambiguous.")
+	}
+}
+
+func isFunctionStart(trimmedLine string) bool {
+	for _, pattern := range functionStartPatterns {
+		if pattern.MatchString(trimmedLine) {
+			return true
+		}
+	}
+	return false
+}
+
+func findMatchingBraceLine(lines []string, startLine int) (int, bool) {
+	depth := 0
+	started := false
+
+	for lineIndex := startLine; lineIndex < len(lines); lineIndex++ {
+		for _, r := range lines[lineIndex] {
+			switch r {
+			case '{':
+				depth++
+				started = true
+			case '}':
+				if started {
+					depth--
+					if depth == 0 {
+						return lineIndex, true
+					}
+				}
+			}
+		}
+	}
+
+	return 0, false
+}
+
+func indentForBlock(signatureLine string) string {
+	indentWidth := len(signatureLine) - len(strings.TrimLeft(signatureLine, " \t"))
+	baseIndent := signatureLine[:indentWidth]
+	if strings.HasPrefix(baseIndent, "\t") {
+		return baseIndent + "\t"
+	}
+	return baseIndent + "  "
+}

--- a/apps/daemon/internal/edits/planner.go
+++ b/apps/daemon/internal/edits/planner.go
@@ -1,1 +1,223 @@
 package edits
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"vocoding.net/vocode/v2/apps/daemon/internal/agent"
+	protocol "vocoding.net/vocode/v2/packages/protocol/go"
+)
+
+type Planner struct {
+	validator *Validator
+}
+
+func NewPlanner() *Planner {
+	return &Planner{validator: NewValidator()}
+}
+
+func (p *Planner) BuildActions(params protocol.EditApplyParams, plan agent.EditPlan) ([]protocol.EditAction, *protocol.EditFailure) {
+	switch plan.Intent.Kind {
+	case agent.EditIntentInsertStatementInCurrentFunction:
+		action, failure := p.buildInsertStatementAction(params, plan.Intent)
+		if failure != nil {
+			return nil, failure
+		}
+		return []protocol.EditAction{action}, nil
+	case agent.EditIntentReplaceAnchoredBlock:
+		action := protocol.ReplaceBetweenAnchorsAction{
+			Kind: "replace_between_anchors",
+			Path: params.ActiveFile,
+			Anchor: protocol.Anchor{
+				Before: plan.Intent.Before,
+				After:  plan.Intent.After,
+			},
+			NewText: plan.Intent.NewText,
+		}
+		if failure := p.validator.ValidateAction(params.FileText, action); failure != nil {
+			return nil, failure
+		}
+		return []protocol.EditAction{action}, nil
+	case agent.EditIntentAppendImportIfMissing:
+		action, failure := p.buildAppendImportAction(params, plan.Intent)
+		if failure != nil {
+			return nil, failure
+		}
+		if action == nil {
+			return []protocol.EditAction{}, nil
+		}
+		return []protocol.EditAction{*action}, nil
+	default:
+		return nil, editFailure("unsupported_instruction", fmt.Sprintf("Unsupported intent kind %q.", plan.Intent.Kind))
+	}
+}
+
+func (p *Planner) buildInsertStatementAction(params protocol.EditApplyParams, intent agent.EditIntent) (protocol.ReplaceBetweenAnchorsAction, *protocol.EditFailure) {
+	block, failure := findSingleFunctionBlock(params.FileText)
+	if failure != nil {
+		return protocol.ReplaceBetweenAnchorsAction{}, failure
+	}
+
+	statement := strings.TrimSpace(intent.Statement)
+	if statement == "" {
+		return protocol.ReplaceBetweenAnchorsAction{}, editFailure("unsupported_instruction", "Insert statement instruction did not include a statement.")
+	}
+	statement = strings.TrimRight(statement, "\n")
+	if !strings.HasSuffix(statement, ";") {
+		statement += ";"
+	}
+
+	newText := block.between
+	if strings.TrimSpace(newText) == "" {
+		newText = "\n"
+	}
+	if newText == "\n" {
+		newText += block.indent + statement + "\n"
+	} else {
+		newText += block.indent + statement + "\n"
+	}
+
+	action := protocol.ReplaceBetweenAnchorsAction{
+		Kind: "replace_between_anchors",
+		Path: params.ActiveFile,
+		Anchor: protocol.Anchor{
+			Before: block.beforeLine,
+			After:  block.afterAnchor,
+		},
+		NewText: newText,
+	}
+
+	if failure := p.validator.ValidateAction(params.FileText, action); failure != nil {
+		return protocol.ReplaceBetweenAnchorsAction{}, failure
+	}
+
+	return action, nil
+}
+
+func (p *Planner) buildAppendImportAction(params protocol.EditApplyParams, intent agent.EditIntent) (*protocol.ReplaceBetweenAnchorsAction, *protocol.EditFailure) {
+	if strings.Contains(params.FileText, intent.Import) {
+		return nil, editFailure("no_change_needed", fmt.Sprintf("Import %q is already present.", intent.Import))
+	}
+
+	ext := strings.ToLower(filepath.Ext(params.ActiveFile))
+	switch ext {
+	case ".go":
+		return p.buildGoImportAction(params, intent.Import)
+	case ".ts", ".tsx", ".js", ".jsx":
+		return p.buildJSImportAction(params, intent.Import)
+	default:
+		return nil, editFailure("unsupported_instruction", fmt.Sprintf("Append import is not supported for %q files yet.", ext))
+	}
+}
+
+func (p *Planner) buildGoImportAction(params protocol.EditApplyParams, importStmt string) (*protocol.ReplaceBetweenAnchorsAction, *protocol.EditFailure) {
+	lines := strings.Split(params.FileText, "\n")
+	packageIndex := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "package ") {
+			packageIndex = i
+			break
+		}
+	}
+	if packageIndex == -1 {
+		return nil, editFailure("missing_anchor", "Could not find a package declaration for Go import insertion.")
+	}
+
+	for i, line := range lines {
+		if strings.TrimSpace(line) != "import (" {
+			continue
+		}
+		closeIndex := -1
+		for j := i + 1; j < len(lines); j++ {
+			if strings.TrimSpace(lines[j]) == ")" {
+				closeIndex = j
+				break
+			}
+		}
+		if closeIndex == -1 {
+			return nil, editFailure("missing_anchor", "Could not find the end of the Go import block.")
+		}
+
+		between := "\n"
+		if closeIndex > i+1 {
+			between += strings.Join(lines[i+1:closeIndex], "\n")
+			between += "\n"
+		}
+		newText := between + "\t" + strings.TrimPrefix(importStmt, "import ") + "\n"
+		action := protocol.ReplaceBetweenAnchorsAction{
+			Kind:    "replace_between_anchors",
+			Path:    params.ActiveFile,
+			Anchor:  protocol.Anchor{Before: lines[i], After: lines[closeIndex]},
+			NewText: newText,
+		}
+		if failure := p.validator.ValidateAction(params.FileText, action); failure != nil {
+			return nil, failure
+		}
+		return &action, nil
+	}
+
+	before := lines[packageIndex]
+	after := strings.Join(lines[packageIndex+1:], "\n")
+	if after == "" {
+		return nil, editFailure("missing_anchor", "Could not find a safe insertion point after the package declaration.")
+	}
+
+	action := protocol.ReplaceBetweenAnchorsAction{
+		Kind:    "replace_between_anchors",
+		Path:    params.ActiveFile,
+		Anchor:  protocol.Anchor{Before: before, After: after},
+		NewText: "\n\n" + importStmt + "\n",
+	}
+	if failure := p.validator.ValidateAction(params.FileText, action); failure != nil {
+		return nil, failure
+	}
+	return &action, nil
+}
+
+func (p *Planner) buildJSImportAction(params protocol.EditApplyParams, importStmt string) (*protocol.ReplaceBetweenAnchorsAction, *protocol.EditFailure) {
+	lines := strings.Split(params.FileText, "\n")
+	lastImportIndex := -1
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "import ") {
+			lastImportIndex = i
+			continue
+		}
+		if strings.TrimSpace(line) != "" && lastImportIndex != -1 {
+			break
+		}
+	}
+
+	if lastImportIndex != -1 {
+		before := lines[lastImportIndex]
+		after := strings.Join(lines[lastImportIndex+1:], "\n")
+		if after == "" {
+			return nil, editFailure("missing_anchor", "Could not find a safe insertion point after the final import.")
+		}
+		action := protocol.ReplaceBetweenAnchorsAction{
+			Kind:    "replace_between_anchors",
+			Path:    params.ActiveFile,
+			Anchor:  protocol.Anchor{Before: before, After: after},
+			NewText: "\n" + importStmt + "\n",
+		}
+		if failure := p.validator.ValidateAction(params.FileText, action); failure != nil {
+			return nil, failure
+		}
+		return &action, nil
+	}
+
+	if len(lines) < 2 {
+		return nil, editFailure("missing_anchor", "Could not find a safe insertion point at the top of the file.")
+	}
+
+	action := protocol.ReplaceBetweenAnchorsAction{
+		Kind:    "replace_between_anchors",
+		Path:    params.ActiveFile,
+		Anchor:  protocol.Anchor{Before: lines[0], After: strings.Join(lines[1:], "\n")},
+		NewText: "\n" + importStmt + "\n",
+	}
+	if failure := p.validator.ValidateAction(params.FileText, action); failure != nil {
+		return nil, failure
+	}
+	return &action, nil
+}

--- a/apps/daemon/internal/edits/service.go
+++ b/apps/daemon/internal/edits/service.go
@@ -1,49 +1,42 @@
 package edits
 
 import (
-	"strings"
-
+	"vocoding.net/vocode/v2/apps/daemon/internal/agent"
 	protocol "vocoding.net/vocode/v2/packages/protocol/go"
 )
 
-type Service struct{}
+type Service struct {
+	agentService *agent.Service
+	planner      *Planner
+}
 
-func NewService() *Service {
-	return &Service{}
+func NewService(agentService *agent.Service) *Service {
+	return &Service{
+		agentService: agentService,
+		planner:      NewPlanner(),
+	}
 }
 
 func (s *Service) Apply(params protocol.EditApplyParams) (protocol.EditApplyResult, error) {
-	before, after, ok := firstBraceAnchors(params.FileText)
-	if !ok {
+	planResult := s.agentService.PlanEdit(params)
+	if planResult.Failure != nil {
 		return protocol.EditApplyResult{
 			Actions: []protocol.EditAction{},
+			Failure: planResult.Failure,
 		}, nil
 	}
 
-	action := protocol.ReplaceBetweenAnchorsAction{
-		Kind: "replace_between_anchors",
-		Path: params.ActiveFile,
-		Anchor: protocol.Anchor{
-			Before: before,
-			After:  after,
-		},
-		NewText: "\n  console.log(\"hi from vocode\");\n",
+	actions, failure := s.planner.BuildActions(params, *planResult.Plan)
+	if failure != nil {
+		return protocol.EditApplyResult{
+			Actions: []protocol.EditAction{},
+			Failure: failure,
+		}, nil
 	}
 
-	return protocol.EditApplyResult{
-		Actions: []protocol.EditAction{action},
-	}, nil
+	return protocol.EditApplyResult{Actions: actions}, nil
 }
 
-func firstBraceAnchors(fileText string) (before string, after string, ok bool) {
-	lines := strings.Split(fileText, "\n")
-
-	for _, line := range lines {
-		trimmed := strings.TrimSpace(line)
-		if strings.Contains(line, "{") && trimmed != "{" {
-			return line, "}", true
-		}
-	}
-
-	return "", "", false
+func editFailure(code string, message string) *protocol.EditFailure {
+	return &protocol.EditFailure{Code: code, Message: message}
 }

--- a/apps/daemon/internal/edits/service_test.go
+++ b/apps/daemon/internal/edits/service_test.go
@@ -1,0 +1,124 @@
+package edits
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"vocoding.net/vocode/v2/apps/daemon/internal/agent"
+	protocol "vocoding.net/vocode/v2/packages/protocol/go"
+)
+
+func TestApplyInsertStatementInCurrentFunction(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(agent.NewService())
+	fileText := readFixture(t, "single-function.ts")
+
+	result, err := service.Apply(protocol.EditApplyParams{
+		Instruction: "insert statement `console.log(\"done\")` inside current function",
+		ActiveFile:  "/tmp/single-function.ts",
+		FileText:    fileText,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if result.Failure != nil {
+		t.Fatalf("Apply returned failure: %+v", *result.Failure)
+	}
+	if len(result.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(result.Actions))
+	}
+
+	action := result.Actions[0]
+	if !strings.Contains(action.NewText, `console.log("done");`) {
+		t.Fatalf("expected generated statement, got %q", action.NewText)
+	}
+	if strings.Contains(action.NewText, "hi from vocode") {
+		t.Fatalf("legacy demo insertion leaked into action: %q", action.NewText)
+	}
+}
+
+func TestApplyFailsForAmbiguousCurrentFunction(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(agent.NewService())
+	fileText := readFixture(t, "multi-function.ts")
+
+	result, err := service.Apply(protocol.EditApplyParams{
+		Instruction: "insert statement `console.log(\"done\")` inside current function",
+		ActiveFile:  "/tmp/multi-function.ts",
+		FileText:    fileText,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if result.Failure == nil {
+		t.Fatal("expected failure but got success")
+	}
+	if result.Failure.Code != "ambiguous_target" {
+		t.Fatalf("expected ambiguous_target failure, got %+v", *result.Failure)
+	}
+}
+
+func TestApplyReplaceAnchoredBlock(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(agent.NewService())
+	fileText := readFixture(t, "anchored-block.ts")
+
+	result, err := service.Apply(protocol.EditApplyParams{
+		Instruction: "replace block after \"export function firstBraceAnchors() {\" before \"}\" with `\\n  return \\\"updated\\\";\\n`",
+		ActiveFile:  "/tmp/anchored-block.ts",
+		FileText:    fileText,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if result.Failure != nil {
+		t.Fatalf("unexpected failure: %+v", *result.Failure)
+	}
+	if len(result.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(result.Actions))
+	}
+	if !strings.Contains(result.Actions[0].Anchor.Before, "firstBraceAnchors") {
+		t.Fatalf("expected anchored action to target firstBraceAnchors, got %+v", result.Actions[0].Anchor)
+	}
+}
+
+func TestApplyAppendImportIfMissing(t *testing.T) {
+	t.Parallel()
+
+	service := NewService(agent.NewService())
+	fileText := readFixture(t, "imports.go")
+
+	result, err := service.Apply(protocol.EditApplyParams{
+		Instruction: "append import `import \"fmt\"` if missing",
+		ActiveFile:  "/tmp/imports.go",
+		FileText:    fileText,
+	})
+	if err != nil {
+		t.Fatalf("Apply returned error: %v", err)
+	}
+	if result.Failure != nil {
+		t.Fatalf("unexpected failure: %+v", *result.Failure)
+	}
+	if len(result.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(result.Actions))
+	}
+	if !strings.Contains(result.Actions[0].NewText, `import "fmt"`) {
+		t.Fatalf("expected import insertion, got %q", result.Actions[0].NewText)
+	}
+}
+
+func readFixture(t *testing.T, name string) string {
+	t.Helper()
+
+	path := filepath.Join("testdata", name)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return string(data)
+}

--- a/apps/daemon/internal/edits/testdata/anchored-block.ts
+++ b/apps/daemon/internal/edits/testdata/anchored-block.ts
@@ -1,0 +1,3 @@
+export function firstBraceAnchors() {
+  return "old";
+}

--- a/apps/daemon/internal/edits/testdata/imports.go
+++ b/apps/daemon/internal/edits/testdata/imports.go
@@ -1,0 +1,5 @@
+package main
+
+func main() {
+	println("ready")
+}

--- a/apps/daemon/internal/edits/testdata/multi-function.ts
+++ b/apps/daemon/internal/edits/testdata/multi-function.ts
@@ -1,0 +1,7 @@
+export function firstBraceAnchors() {
+  return 1;
+}
+
+export function secondBraceAnchors() {
+  return 2;
+}

--- a/apps/daemon/internal/edits/testdata/single-function.ts
+++ b/apps/daemon/internal/edits/testdata/single-function.ts
@@ -1,0 +1,3 @@
+export function greet(name: string) {
+  return `hello ${name}`;
+}

--- a/apps/daemon/internal/edits/validator.go
+++ b/apps/daemon/internal/edits/validator.go
@@ -1,1 +1,22 @@
 package edits
+
+import protocol "vocoding.net/vocode/v2/packages/protocol/go"
+
+type Validator struct{}
+
+func NewValidator() *Validator {
+	return &Validator{}
+}
+
+func (v *Validator) ValidateAction(fileText string, action protocol.ReplaceBetweenAnchorsAction) *protocol.EditFailure {
+	start, end, failure := findUniqueAnchoredRange(fileText, action.Anchor.Before, action.Anchor.After)
+	if failure != nil {
+		return failure
+	}
+
+	if end < start {
+		return editFailure("validation_failed", "Resolved anchor range was invalid.")
+	}
+
+	return nil
+}

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsc -w -p tsconfig.json",
+    "test": "pnpm build && node --test dist",
     "lint": "biome check src",
     "lint:fix": "biome check --write src",
     "typecheck": "tsc -p tsconfig.json --noEmit"

--- a/apps/vscode-extension/src/commands/apply-edit-helpers.ts
+++ b/apps/vscode-extension/src/commands/apply-edit-helpers.ts
@@ -1,0 +1,49 @@
+import type { ReplaceBetweenAnchorsAction } from "@vocode/protocol";
+
+function findUniqueOccurrence(
+  documentText: string,
+  needle: string,
+  searchStart: number,
+  label: string,
+): number {
+  const firstIndex = documentText.indexOf(needle, searchStart);
+  if (firstIndex === -1) {
+    throw new Error(
+      `Could not find ${label} anchor: ${JSON.stringify(needle)}`,
+    );
+  }
+
+  const secondIndex = documentText.indexOf(needle, firstIndex + 1);
+  if (secondIndex !== -1) {
+    throw new Error(
+      `Anchor was ambiguous for ${label}: ${JSON.stringify(needle)}`,
+    );
+  }
+
+  return firstIndex;
+}
+
+export function applyReplaceBetweenAnchors(
+  documentText: string,
+  action: ReplaceBetweenAnchorsAction,
+): string {
+  const beforeIndex = findUniqueOccurrence(
+    documentText,
+    action.anchor.before,
+    0,
+    "before",
+  );
+
+  const searchStart = beforeIndex + action.anchor.before.length;
+  const afterIndex = findUniqueOccurrence(
+    documentText,
+    action.anchor.after,
+    searchStart,
+    "after",
+  );
+
+  const prefix = documentText.slice(0, searchStart);
+  const suffix = documentText.slice(afterIndex);
+
+  return `${prefix}${action.newText}${suffix}`;
+}

--- a/apps/vscode-extension/src/commands/apply-edit.test.ts
+++ b/apps/vscode-extension/src/commands/apply-edit.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ReplaceBetweenAnchorsAction } from "@vocode/protocol";
+
+import { applyReplaceBetweenAnchors } from "./apply-edit-helpers";
+
+test("applyReplaceBetweenAnchors replaces the range between unique anchors", () => {
+  const action: ReplaceBetweenAnchorsAction = {
+    kind: "replace_between_anchors",
+    path: "/tmp/example.ts",
+    anchor: {
+      before: "function firstBraceAnchors() {",
+      after: "}",
+    },
+    newText: '\n  console.log("updated safely");\n',
+  };
+
+  const input = [
+    "function firstBraceAnchors() {",
+    '  console.log("hi from vocode");',
+    "}",
+  ].join("\n");
+
+  const output = applyReplaceBetweenAnchors(input, action);
+
+  assert.match(output, /updated safely/);
+  assert.doesNotMatch(output, /hi from vocode/);
+});
+
+test("applyReplaceBetweenAnchors rejects ambiguous anchors", () => {
+  const action: ReplaceBetweenAnchorsAction = {
+    kind: "replace_between_anchors",
+    path: "/tmp/example.ts",
+    anchor: {
+      before: "function firstBraceAnchors() {",
+      after: "}",
+    },
+    newText: '\n  console.log("updated safely");\n',
+  };
+
+  const input = [
+    "function firstBraceAnchors() {",
+    "}",
+    "",
+    "function firstBraceAnchors() {",
+    "}",
+  ].join("\n");
+
+  assert.throws(() => applyReplaceBetweenAnchors(input, action), {
+    message: /ambiguous/,
+  });
+});

--- a/apps/vscode-extension/src/commands/apply-edit.ts
+++ b/apps/vscode-extension/src/commands/apply-edit.ts
@@ -1,36 +1,9 @@
-import type {
-  EditApplyParams,
-  ReplaceBetweenAnchorsAction,
-} from "@vocode/protocol";
+import type { EditApplyParams } from "@vocode/protocol";
 import { isEditApplyResult } from "@vocode/protocol";
 import * as vscode from "vscode";
 
+import { applyReplaceBetweenAnchors } from "./apply-edit-helpers";
 import type { CommandDefinition } from "./types";
-
-function applyReplaceBetweenAnchors(
-  documentText: string,
-  action: ReplaceBetweenAnchorsAction,
-): string {
-  const beforeIndex = documentText.indexOf(action.anchor.before);
-  if (beforeIndex === -1) {
-    throw new Error(
-      `Could not find before anchor: ${JSON.stringify(action.anchor.before)}`,
-    );
-  }
-
-  const searchStart = beforeIndex + action.anchor.before.length;
-  const afterIndex = documentText.indexOf(action.anchor.after, searchStart);
-  if (afterIndex === -1) {
-    throw new Error(
-      `Could not find after anchor: ${JSON.stringify(action.anchor.after)}`,
-    );
-  }
-
-  const prefix = documentText.slice(0, searchStart);
-  const suffix = documentText.slice(afterIndex);
-
-  return `${prefix}${action.newText}${suffix}`;
-}
 
 async function replaceWholeDocument(
   editor: vscode.TextEditor,
@@ -65,7 +38,8 @@ export const applyEditCommand: CommandDefinition = {
     const instruction = await vscode.window.showInputBox({
       title: "Vocode Apply Edit",
       prompt: "Describe the edit to apply",
-      placeHolder: "Insert a console.log inside the current function",
+      placeHolder:
+        'Insert statement "console.log(value)" inside current function',
       ignoreFocusOut: true,
     });
 
@@ -86,6 +60,20 @@ export const applyEditCommand: CommandDefinition = {
       throw new Error("Daemon returned an invalid edit/apply result.");
     }
 
+    if (result.failure) {
+      void vscode.window.showWarningMessage(
+        `Vocode could not produce a safe edit: ${result.failure.message}`,
+      );
+      return;
+    }
+
+    if (result.actions.length === 0) {
+      void vscode.window.showWarningMessage(
+        "Vocode could not produce a safe edit for that instruction.",
+      );
+      return;
+    }
+
     let nextText = document.getText();
 
     for (const action of result.actions) {
@@ -93,14 +81,12 @@ export const applyEditCommand: CommandDefinition = {
         throw new Error(`Received action for unsupported file: ${action.path}`);
       }
 
-      for (const action of result.actions) {
-        switch (action.kind) {
-          case "replace_between_anchors":
-            nextText = applyReplaceBetweenAnchors(nextText, action);
-            break;
-          default:
-            throw new Error(`Unsupported action kind: ${action.kind}`);
-        }
+      switch (action.kind) {
+        case "replace_between_anchors":
+          nextText = applyReplaceBetweenAnchors(nextText, action);
+          break;
+        default:
+          throw new Error(`Unsupported action kind: ${action.kind}`);
       }
     }
 

--- a/docs/editing-model.md
+++ b/docs/editing-model.md
@@ -7,6 +7,24 @@ Vocode uses a structured editing model so AI-driven code changes stay reliable, 
 Magical UX, deterministic core:
 users describe changes naturally; the system turns them into structured actions that can be validated, diffed, and applied safely.
 
+## Current Implemented Slice
+
+Today's daemon ships a deliberately small, rule-based planning layer. It is not the final editing system, but it is a safe vertical slice that proves the daemon-first architecture.
+
+The currently supported intents are:
+
+- `insert statement "..." inside current function`
+  - Only succeeds when the active file contains exactly one supported function-shaped block.
+  - The inserted statement is appended just before that function's closing brace.
+- `replace block after "..." before "..." with "..."`
+  - Both anchors must resolve uniquely in the active file.
+  - Ambiguous or missing anchors produce a structured failure instead of guessing.
+- `append import "..." if missing`
+  - Currently supported for Go files and top-of-file JS/TS import sections.
+  - If the import already exists, the daemon returns a structured no-change response.
+
+These rules intentionally fail closed when the daemon cannot map the instruction to a unique edit.
+
 ## Goals
 
 - The model must be semantic, inspectable, reversible, transportable, and independent of any single parser or editor.
@@ -25,15 +43,20 @@ User intent -> plan -> structured edit actions -> target resolution -> validatio
 
 ## Layers
 
-### 1) Edit actions
+### 1) Edit planning
+
+- Interprets a user instruction into a narrow, deterministic edit intent.
+- The current planner lives behind the daemon's `internal/agent` boundary so richer planners can replace the rules later without changing the extension contract.
+
+### 2) Edit actions
 
 - Describe what change should happen (create file, delete file, insert before symbol, replace function body, replace anchored range, add import, rename symbol, etc.).
 
-### 2) Target resolution
+### 3) Target resolution
 
 - Determines where the action applies using file path, symbol summaries, text anchors, AST queries, or LSP data.
 
-### 3) Application
+### 4) Application
 
 - Performs the final mutation and generates a diff.
 
@@ -136,7 +159,7 @@ Every edit must be validated before apply by checking:
 
 - file exists when required
 - target resolves uniquely
-- fallback anchors still match
+- fallback anchors still match uniquely
 - file has not changed incompatibly
 - edits do not overlap
 - resulting patch is well-formed
@@ -180,4 +203,5 @@ Safety level controls whether Vocode auto-applies, previews first, or asks for c
 ## Summary
 
 - Edit actions describe intent; resolvers determine location.
+- The current rule-based planner is a safe starting slice, not the end state.
 - This keeps the user experience magical while the system stays deterministic and evolvable.

--- a/packages/protocol/schema/common.schema.json
+++ b/packages/protocol/schema/common.schema.json
@@ -10,6 +10,24 @@
         "after": { "type": "string" }
       },
       "required": ["before", "after"]
+    },
+    "EditFailure": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "code": {
+          "type": "string",
+          "enum": [
+            "unsupported_instruction",
+            "ambiguous_target",
+            "missing_anchor",
+            "validation_failed",
+            "no_change_needed"
+          ]
+        },
+        "message": { "type": "string" }
+      },
+      "required": ["code", "message"]
     }
   }
 }

--- a/packages/protocol/schema/edit-apply.params.schema.json
+++ b/packages/protocol/schema/edit-apply.params.schema.json
@@ -15,5 +15,5 @@
       "type": "string"
     }
   },
-  "required": ["instruction"]
+  "required": ["instruction", "activeFile", "fileText"]
 }

--- a/packages/protocol/schema/edit-apply.result.schema.json
+++ b/packages/protocol/schema/edit-apply.result.schema.json
@@ -10,6 +10,9 @@
       "items": {
         "$ref": "./edit-action.schema.json"
       }
+    },
+    "failure": {
+      "$ref": "./common.schema.json#/$defs/EditFailure"
     }
   },
   "required": ["actions"]

--- a/packages/protocol/typescript/validators.ts
+++ b/packages/protocol/typescript/validators.ts
@@ -16,6 +16,16 @@ function isAnchor(value: unknown): value is { before: string; after: string } {
   );
 }
 
+function isEditFailure(
+  value: unknown,
+): value is { code: string; message: string } {
+  return (
+    isRecord(value) &&
+    typeof value.code === "string" &&
+    typeof value.message === "string"
+  );
+}
+
 export function isPingResult(value: unknown): value is PingResult {
   return isRecord(value) && value.message === "pong";
 }
@@ -34,6 +44,7 @@ export function isEditApplyResult(value: unknown): value is EditApplyResult {
   return (
     isRecord(value) &&
     Array.isArray(value.actions) &&
-    value.actions.every(isEditAction)
+    value.actions.every(isEditAction) &&
+    (value.failure === undefined || isEditFailure(value.failure))
   );
 }

--- a/scripts/codegen/generate-protocol-go.mjs
+++ b/scripts/codegen/generate-protocol-go.mjs
@@ -8,6 +8,7 @@ const outFile = path.join(outDir, "types.generated.go");
 
 const entries = [
   { file: "common.schema.json", def: "Anchor", name: "Anchor" },
+  { file: "common.schema.json", def: "EditFailure", name: "EditFailure" },
   {
     file: "edit-action.replace-between-anchors.schema.json",
     name: "ReplaceBetweenAnchorsAction",
@@ -177,8 +178,12 @@ function schemaToGoType(schema, currentAbsPath, ctx) {
     for (const [jsonName, propSchema] of propEntries) {
       const fieldName = toGoFieldName(jsonName);
       const goType = schemaToGoType(propSchema, currentAbsPath, ctx);
-      const omitempty = required.has(jsonName) ? "" : ",omitempty";
-      lines.push(`\t${fieldName} ${goType} \`json:"${jsonName}${omitempty}"\``);
+      const isRequired = required.has(jsonName);
+      const fieldType = isRequired ? goType : toOptionalGoType(goType);
+      const omitempty = isRequired ? "" : ",omitempty";
+      lines.push(
+        `	${fieldName} ${fieldType} \`json:"${jsonName}${omitempty}"\``,
+      );
     }
 
     lines.push("}");
@@ -188,6 +193,25 @@ function schemaToGoType(schema, currentAbsPath, ctx) {
   throw new Error(
     `Unsupported schema in ${ctx.name}: ${JSON.stringify(schema, null, 2)}`,
   );
+}
+
+function toOptionalGoType(goType) {
+  if (
+    goType === "string" ||
+    goType === "int" ||
+    goType === "float64" ||
+    goType === "bool" ||
+    goType === "interface{}" ||
+    goType.startsWith("[]")
+  ) {
+    return goType;
+  }
+
+  if (goType.startsWith("*")) {
+    return goType;
+  }
+
+  return `*${goType}`;
 }
 
 function emitEntry(entry) {


### PR DESCRIPTION
### Motivation

- Remove the previous demo stub that unconditionally inserted `console.log("hi from vocode")` and replace it with a deterministic planning boundary so the daemon no longer guesses edits.  
- Provide a minimal, rule-based planner that maps `instruction` + `activeFile` + `fileText` into a small set of safe intents and fail closed on ambiguity.  
- Make anchor resolution and validation conservative so ambiguous/missing anchors return structured failure reasons instead of silently picking the first match.  
- Surface structured failure information to the VS Code extension so users see a warning when no safe edit can be produced.  

### Description

- Implemented a small agent planning layer under `apps/daemon/internal/agent/` including `intent.go`, `models.go`, `planner.go`, and `service.go` that recognizes three v1 intents: `insert statement inside current function`, `replace anchored block`, and `append import if missing`.  
- Reworked the edits pipeline: `apps/daemon/internal/edits/service.go` now delegates to `agent.Service` and `edits.Planner` to produce `protocol.EditAction` values instead of the prior hard-coded insertion.  
- Strengthened anchor logic and safer target resolution in `apps/daemon/internal/edits/anchors.go`, added `validator.go` to validate resolved ranges, and implemented deterministic action construction in `apps/daemon/internal/edits/planner.go`.  
- Extended protocol schemas under `packages/protocol/schema/` to require `activeFile` and `fileText` in `EditApplyParams` and added an `EditFailure` shape to `common.schema.json` so `EditApplyResult` can return structured `failure` information, and updated TypeScript validators (`packages/protocol/typescript/validators.ts`) and Go codegen accordingly.  
- Updated the VS Code extension: extracted anchor-application helpers to `apps/vscode-extension/src/commands/apply-edit-helpers.ts`, updated `apply-edit.ts` to show warnings when `result.failure` is present or `result.actions` is empty, and tightened anchor uniqueness checks.  
- Added fixture-style tests: daemon Go tests in `apps/daemon/internal/edits/service_test.go` with `testdata/` fixtures to exercise insert/replace/append behaviors and extension-side tests in `apps/vscode-extension/src/commands/apply-edit.test.ts` for `replace_between_anchors` application logic.  
- Documentation updated: `docs/editing-model.md` and `README.md` now describe the implemented safe slice and note that the planner is intentionally rule-based for this initial vertical slice.  

### Testing

- Ran `go test ./apps/daemon/...` which executed the new daemon edit tests and passed.  
- Ran the extension tests via `pnpm --filter @vocode/vscode-extension test` which builds the extension types and ran the `applyReplaceBetweenAnchors` tests (both passed).  
- Ran `pnpm codegen`/`pnpm --filter @vocode/protocol build` to regenerate types after schema changes and the generated TS/Go types built successfully.  
- Ran linter/format fixes with `pnpm lint:fix`/`pnpm lint` and the workspace checks completed without remaining issues.