### PR TITLE
feat(vscode): implement EditAction to WorkspaceEdit adapter

### DIFF
--- a/apps/vscode-extension/src/commands/apply-edit-helpers.ts
+++ b/apps/vscode-extension/src/commands/apply-edit-helpers.ts
@@ -1,5 +1,12 @@
 import type { ReplaceBetweenAnchorsAction } from "@vocode/protocol";
 
+export interface AnchoredReplacement {
+  startOffset: number;
+  endOffset: number;
+  replacementText: string;
+  nextText: string;
+}
+
 function findUniqueOccurrence(
   text: string,
   needle: string,
@@ -31,6 +38,13 @@ export function applyReplaceBetweenAnchors(
   documentText: string,
   action: ReplaceBetweenAnchorsAction,
 ): string {
+  return resolveReplaceBetweenAnchors(documentText, action).nextText;
+}
+
+export function resolveReplaceBetweenAnchors(
+  documentText: string,
+  action: ReplaceBetweenAnchorsAction,
+): AnchoredReplacement {
   const beforeIndex = findUniqueOccurrence(
     documentText,
     action.anchor.before,
@@ -48,6 +62,12 @@ export function applyReplaceBetweenAnchors(
 
   const prefix = documentText.slice(0, searchStart);
   const suffix = documentText.slice(afterIndex);
+  const nextText = `${prefix}${action.newText}${suffix}`;
 
-  return `${prefix}${action.newText}${suffix}`;
+  return {
+    startOffset: searchStart,
+    endOffset: afterIndex,
+    replacementText: action.newText,
+    nextText,
+  };
 }

--- a/apps/vscode-extension/src/commands/apply-edit.test.ts
+++ b/apps/vscode-extension/src/commands/apply-edit.test.ts
@@ -2,7 +2,10 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import type { ReplaceBetweenAnchorsAction } from "@vocode/protocol";
 
-import { applyReplaceBetweenAnchors } from "./apply-edit-helpers";
+import {
+  applyReplaceBetweenAnchors,
+  resolveReplaceBetweenAnchors,
+} from "./apply-edit-helpers";
 
 test("applyReplaceBetweenAnchors replaces the range between unique anchors", () => {
   const action: ReplaceBetweenAnchorsAction = {
@@ -81,4 +84,68 @@ test("applyReplaceBetweenAnchors throws when after anchor is ambiguous", () => {
   assert.throws(() => applyReplaceBetweenAnchors(input, action), {
     message: /matched multiple locations/,
   });
+});
+
+test("resolveReplaceBetweenAnchors returns exact offsets for editor range edits", () => {
+  const action: ReplaceBetweenAnchorsAction = {
+    kind: "replace_between_anchors",
+    path: "/tmp/example.ts",
+    anchor: {
+      before: "const value = 1;",
+      after: "return value;",
+    },
+    newText: "\nconst value = 2;\n",
+  };
+
+  const input = [
+    "function run() {",
+    "const value = 1;",
+    "return value;",
+    "}",
+  ].join("\n");
+
+  const replacement = resolveReplaceBetweenAnchors(input, action);
+
+  assert.equal(
+    input.slice(replacement.startOffset, replacement.endOffset),
+    "\n",
+  );
+  assert.match(replacement.nextText, /const value = 2/);
+  assert.equal(replacement.replacementText, action.newText);
+});
+
+test("resolveReplaceBetweenAnchors supports sequential actions against updated text", () => {
+  const firstAction: ReplaceBetweenAnchorsAction = {
+    kind: "replace_between_anchors",
+    path: "/tmp/example.ts",
+    anchor: {
+      before: "function run() {",
+      after: "const second = 2;",
+    },
+    newText: "\n  const first = 100;\n",
+  };
+
+  const secondAction: ReplaceBetweenAnchorsAction = {
+    kind: "replace_between_anchors",
+    path: "/tmp/example.ts",
+    anchor: {
+      before: "const second = 2;",
+      after: "}",
+    },
+    newText: "\n  return first + second;\n",
+  };
+
+  const input = [
+    "function run() {",
+    "  const first = 1;",
+    "const second = 2;",
+    "  return first;",
+    "}",
+  ].join("\n");
+
+  const first = resolveReplaceBetweenAnchors(input, firstAction);
+  const second = resolveReplaceBetweenAnchors(first.nextText, secondAction);
+
+  assert.match(second.nextText, /const first = 100/);
+  assert.match(second.nextText, /return first \+ second/);
 });

--- a/apps/vscode-extension/src/commands/apply-edit.ts
+++ b/apps/vscode-extension/src/commands/apply-edit.ts
@@ -2,29 +2,12 @@ import type { EditApplyParams } from "@vocode/protocol";
 import { isEditApplyResult } from "@vocode/protocol";
 import * as vscode from "vscode";
 
-import { applyReplaceBetweenAnchors } from "./apply-edit-helpers";
+import { resolveReplaceBetweenAnchors } from "./apply-edit-helpers";
 import type { CommandDefinition } from "./types";
 
-// TEMPORARY: Replace the whole document with the new text.
-// TODO: Replace the structured edit with the new data
-async function replaceWholeDocument(
-  editor: vscode.TextEditor,
-  newText: string,
-): Promise<void> {
-  const document = editor.document;
-  const lastLine = document.lineAt(document.lineCount - 1);
-  const fullRange = new vscode.Range(
-    new vscode.Position(0, 0),
-    lastLine.rangeIncludingLineBreak.end,
-  );
-
-  const success = await editor.edit((editBuilder) => {
-    editBuilder.replace(fullRange, newText);
-  });
-
-  if (!success) {
-    throw new Error("VS Code failed to apply the edit.");
-  }
+interface DocumentEditState {
+  document: vscode.TextDocument;
+  nextText: string;
 }
 
 export const applyEditCommand: CommandDefinition = {
@@ -81,24 +64,54 @@ export const applyEditCommand: CommandDefinition = {
         if (!result.actions) {
           throw new Error("Daemon returned success kind without actions.");
         }
-        let nextText = document.getText();
+
+        const workspaceEdit = new vscode.WorkspaceEdit();
+        const documentsByPath = new Map<string, DocumentEditState>();
+
         for (const action of result.actions) {
-          if (action.path !== document.uri.fsPath) {
-            throw new Error(
-              `Received action for unsupported file: ${action.path}`,
-            );
+          let state = documentsByPath.get(action.path);
+          if (!state) {
+            const actionUri = vscode.Uri.file(action.path);
+            const actionDocument =
+              await vscode.workspace.openTextDocument(actionUri);
+            state = {
+              document: actionDocument,
+              nextText: actionDocument.getText(),
+            };
+            documentsByPath.set(action.path, state);
           }
 
           switch (action.kind) {
-            case "replace_between_anchors":
-              nextText = applyReplaceBetweenAnchors(nextText, action);
+            case "replace_between_anchors": {
+              const replacement = resolveReplaceBetweenAnchors(
+                state.nextText,
+                action,
+              );
+
+              const range = new vscode.Range(
+                state.document.positionAt(replacement.startOffset),
+                state.document.positionAt(replacement.endOffset),
+              );
+
+              workspaceEdit.replace(
+                state.document.uri,
+                range,
+                replacement.replacementText,
+              );
+
+              state.nextText = replacement.nextText;
               break;
+            }
             default:
               throw new Error(`Unsupported action kind: ${action.kind}`);
           }
         }
 
-        await replaceWholeDocument(editor, nextText);
+        const success = await vscode.workspace.applyEdit(workspaceEdit);
+        if (!success) {
+          throw new Error("VS Code failed to apply the edit.");
+        }
+
         void vscode.window.showInformationMessage("Vocode edit applied.");
         return;
       }


### PR DESCRIPTION
### Motivation
- Replace the temporary whole-document replacement flow with a structured adapter that maps daemon `EditAction[]` to precise editor edits so the extension can apply safe, multi-file, and sequential edits.
- Compute exact offsets for anchor-based actions so multiple actions can be resolved against updated in-memory text and applied as a single undoable workspace edit.

### Description
- Replace whole-document overwrite in `vocode.applyEdit` with a batched `vscode.WorkspaceEdit` builder that opens target documents, computes ranges, and calls `vscode.workspace.applyEdit` (changes in `apps/vscode-extension/src/commands/apply-edit.ts`).
- Add `AnchoredReplacement` type and `resolveReplaceBetweenAnchors` helper that returns `startOffset`, `endOffset`, `replacementText`, and `nextText`, while keeping `applyReplaceBetweenAnchors` as a convenience wrapper (changes in `apps/vscode-extension/src/commands/apply-edit-helpers.ts`).
- Track per-file `DocumentEditState` so sequential actions are resolved against the evolving `nextText` while still producing a single batched `WorkspaceEdit` for application (changes in `apps/vscode-extension/src/commands/apply-edit.ts`).
- Extend unit tests to validate offset/range resolution and sequential action behavior, and update existing anchor safety tests (changes in `apps/vscode-extension/src/commands/apply-edit.test.ts`).

### Testing
- Built the protocol types with `cd packages/protocol && pnpm build` and ran protocol unit tests via `node --test dist/edit-apply-result.test.js dist/voice-transcript-result.test.js`, which passed.
- Built the VS Code extension with `cd apps/vscode-extension && pnpm build` and executed the compiled test file with `node --test dist/commands/apply-edit.test.js`, which ran all tests (6) and passed.
- Ran formatter/linter fixes on modified files and rechecked (`biome`), and fixed issues encountered during linting (formatting applied automatically).
- Ran daemon unit tests with `cd apps/daemon && go test ./internal/edits ./internal/orchestration ./internal/rpc`, which passed.