### PR TITLE
Add action feedback messages during apply-edit

### DIFF
--- a/apps/vscode-extension/src/commands/apply-edit.ts
+++ b/apps/vscode-extension/src/commands/apply-edit.ts
@@ -1,4 +1,8 @@
-import type { EditApplyParams } from "@vocode/protocol";
+import type {
+  EditAction,
+  EditApplyParams,
+  ReplaceBetweenAnchorsAction,
+} from "@vocode/protocol";
 import { isEditApplyResult } from "@vocode/protocol";
 import * as vscode from "vscode";
 
@@ -8,6 +12,31 @@ import type { CommandDefinition } from "./types";
 interface DocumentEditState {
   document: vscode.TextDocument;
   nextText: string;
+}
+
+function describeAction(action: EditAction): string {
+  switch (action.kind) {
+    case "replace_between_anchors":
+      return describeReplaceBetweenAnchorsAction(action);
+    default:
+      return "Editing file…";
+  }
+}
+
+function describeReplaceBetweenAnchorsAction(
+  action: ReplaceBetweenAnchorsAction,
+): string {
+  const nextText = action.newText.toLowerCase();
+  if (
+    nextText.includes("for (") ||
+    nextText.includes("for(") ||
+    nextText.includes("while (") ||
+    nextText.includes("while(")
+  ) {
+    return "Adding loop…";
+  }
+
+  return `Editing ${vscode.workspace.asRelativePath(action.path, false)}…`;
 }
 
 export const applyEditCommand: CommandDefinition = {
@@ -39,7 +68,18 @@ export const applyEditCommand: CommandDefinition = {
       fileText: document.getText(),
     };
 
-    const result = await client.applyEdit(params);
+    const result = await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: "Vocode",
+      },
+      async (progress) => {
+        progress.report({ message: "Understanding request…" });
+        const response = await client.applyEdit(params);
+        progress.report({ message: "Planning changes…" });
+        return response;
+      },
+    );
 
     if (!isEditApplyResult(result)) {
       throw new Error("Daemon returned an invalid edit.apply result.");
@@ -69,6 +109,8 @@ export const applyEditCommand: CommandDefinition = {
         const documentsByPath = new Map<string, DocumentEditState>();
 
         for (const action of result.actions) {
+          void vscode.window.setStatusBarMessage(describeAction(action), 2_000);
+
           let state = documentsByPath.get(action.path);
           if (!state) {
             const actionUri = vscode.Uri.file(action.path);


### PR DESCRIPTION
### Motivation
- Provide users with visible progress and per-action feedback while `vocode.applyEdit` is executing so they can see what the extension/AI is doing.
- Surface higher-level phases (waiting on daemon planning) and per-action descriptions (e.g. adding a loop or editing a specific file) to improve UX during multi-file edits.
- Avoid changing existing edit safety/apply logic and preserve previously authored behavior and guards.

### Description
- Expanded `@vocode/protocol` imports to include `EditAction` and `ReplaceBetweenAnchorsAction` for action inspection. 
- Added `describeAction` and `describeReplaceBetweenAnchorsAction` helpers to generate short user-facing messages such as `Adding loop…` and `Editing <file>…`.
- Wrapped the daemon `applyEdit` request in `vscode.window.withProgress` to show `Understanding request…` and `Planning changes…` notifications while waiting for the daemon.
- Emit per-action status updates via `vscode.window.setStatusBarMessage` before preparing/applying each action, leaving the existing edit resolution and safety checks intact.

### Testing
- Ran `pnpm install` successfully to sync dependencies. (succeeded)