### PR TITLE
Improve transcript error visibility in voice panel

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -94,10 +94,10 @@ function createServices(
       // Only final/committed transcript hypotheses should be forwarded to the core daemon.
       const editor = vscode.window.activeTextEditor;
       if (!editor) {
-        transcriptStore.markError(pendingId);
-        void vscode.window.showWarningMessage(
-          "Open a text editor so Vocode can run actions against the active file.",
-        );
+        const message =
+          "Open a text editor so Vocode can run actions against the active file.";
+        transcriptStore.markError(pendingId, message);
+        void vscode.window.showWarningMessage(message);
         return;
       }
 
@@ -126,11 +126,11 @@ function createServices(
                 : undefined,
           });
         } catch (err) {
-          transcriptStore.markError(pendingId);
           const message =
             err instanceof Error
               ? err.message
               : "unknown voice->transcript error";
+          transcriptStore.markError(pendingId, message);
           void vscode.window.showWarningMessage(
             `Vocode voice error: ${message}`,
           );

--- a/apps/vscode-extension/src/ui/transcript-panel.ts
+++ b/apps/vscode-extension/src/ui/transcript-panel.ts
@@ -110,6 +110,13 @@ export class TranscriptPanelViewProvider
       white-space: pre-wrap;
       word-break: break-word;
     }
+    .error-detail {
+      margin-top: 8px;
+      font-size: 11px;
+      color: var(--vscode-errorForeground);
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
     .card.pending { border-left: 3px solid var(--vscode-progressBar-background); }
     .card.processing { border-left: 3px solid var(--vscode-textLink-foreground); }
     .card.error { border-left: 3px solid var(--vscode-errorForeground); }
@@ -369,6 +376,9 @@ export class TranscriptPanelViewProvider
                 "<span>" + esc(fmtTime(p.receivedAt)) + "</span>" +
               "</div>" +
               '<div class="text">' + esc(p.text) + "</div>" +
+              (p.status === "error" && typeof p.errorMessage === "string" && p.errorMessage.length > 0
+                ? '<div class="error-detail">Error: ' + esc(p.errorMessage) + "</div>"
+                : "") +
             "</div>"
           );
         }

--- a/apps/vscode-extension/src/ui/transcript-store.test.ts
+++ b/apps/vscode-extension/src/ui/transcript-store.test.ts
@@ -64,6 +64,31 @@ test("markError leaves the line visible as error", () => {
 
   store.markError(id);
   assert.equal(store.getSnapshot().pending[0]?.status, "error");
+  assert.equal(store.getSnapshot().pending[0]?.errorMessage, undefined);
+});
+
+test("markError keeps a readable error message for the panel", () => {
+  const store = new TranscriptStore();
+  const id = store.enqueueCommitted("x") as number;
+
+  store.markError(id, "  failed to apply directive  ");
+  assert.equal(store.getSnapshot().pending[0]?.status, "error");
+  assert.equal(
+    store.getSnapshot().pending[0]?.errorMessage,
+    "failed to apply directive",
+  );
+});
+
+test("markProcessing clears stale error message", () => {
+  const store = new TranscriptStore();
+  const id = store.enqueueCommitted("x") as number;
+
+  store.markError(id, "failed");
+  assert.equal(store.getSnapshot().pending[0]?.errorMessage, "failed");
+
+  store.markProcessing(id);
+  assert.equal(store.getSnapshot().pending[0]?.status, "processing");
+  assert.equal(store.getSnapshot().pending[0]?.errorMessage, undefined);
 });
 
 test("setVoiceListening false removes live hypothesis", () => {

--- a/apps/vscode-extension/src/ui/transcript-store.ts
+++ b/apps/vscode-extension/src/ui/transcript-store.ts
@@ -15,6 +15,7 @@ export type PendingTranscript = {
   readonly text: string;
   readonly receivedAt: Date;
   status: PendingStatus;
+  errorMessage?: string;
 };
 
 export type TranscriptPanelSnapshot = {
@@ -166,6 +167,7 @@ export class TranscriptStore {
     const item = this.pending.find((p) => p.id === id);
     if (item) {
       item.status = "processing";
+      item.errorMessage = undefined;
       this.emit();
     }
   }
@@ -212,10 +214,11 @@ export class TranscriptStore {
     this.emit();
   }
 
-  markError(id: number): void {
+  markError(id: number, errorMessage?: string): void {
     const item = this.pending.find((p) => p.id === id);
     if (item) {
       item.status = "error";
+      item.errorMessage = errorMessage?.trim() || undefined;
       this.emit();
     }
   }


### PR DESCRIPTION
### Motivation

- Failures during voice->daemon application were not visible in the UI per-pending item, making it hard for users to diagnose why a committed transcript didn’t run.
- Stale error state could persist when a pending item re-entered processing, causing confusing UI messages.

### Description

- Add an optional `errorMessage?: string` to `PendingTranscript` and persist a trimmed, human-readable reason when a pending line fails. (`apps/vscode-extension/src/ui/transcript-store.ts`)
- Change `markError` to accept `errorMessage?: string` and store the normalized message, and clear `errorMessage` when `markProcessing` is called. (`apps/vscode-extension/src/ui/transcript-store.ts`)
- Pass concrete failure messages from the extension voice flow into the transcript store for both the “no active editor” case and runtime transcript/apply failures. (`apps/vscode-extension/src/extension.ts`)
- Render inline error details for errored Applying cards in the Voice transcript panel and add styling for readable error text. (`apps/vscode-extension/src/ui/transcript-panel.ts`)
- Extend unit tests to assert error-message retention, trimming/normalization, and clearing when processing resumes. (`apps/vscode-extension/src/ui/transcript-store.test.ts`)

### Testing

- Ran `pnpm install` and `pnpm codegen` (succeeded).
- Built and tested the extension unit suite with `pnpm --filter @vocode/vscode-extension build` and `node --test apps/vscode-extension/dist/ui/transcript-store.test.js` (all extension tests passed).
- Performed TypeScript checks with `pnpm --filter @vocode/vscode-extension typecheck` (succeeded) and ran `pnpm --filter @vocode/daemon test` (daemon tests passed).
- Linting via `pnpm lint` completed with no fixes required.
- Performed a daemon smoke test by starting the daemon and sending a whitespace `voice.transcript` request, which returned the expected `-32602 Invalid params` JSON-RPC response.