### PR TITLE
Map STT commit timeout to ElevenLabs inactivity_timeout (max 180s) and surface in UI

### DIFF
--- a/apps/voice/README.md
+++ b/apps/voice/README.md
@@ -37,6 +37,7 @@ Core model selection:
 - `ELEVENLABS_STT_MODEL_ID` (default: `scribe_v2`)
 
 Streaming VAD/segmentation knobs:
+- `VOCODE_VOICE_STT_COMMIT_RESPONSE_TIMEOUT_MS` (default: `5000`; sidecar commit-hold timeout, max `180000` ms / 180s; also mapped to WS `inactivity_timeout` in rounded-up seconds with provider cap; `0` disables both)
 - `VOCODE_VOICE_VAD_THRESHOLD_MULTIPLIER` (default: `2.0`)
 - `VOCODE_VOICE_VAD_START_MS` (default: `60`)
 - `VOCODE_VOICE_VAD_END_MS` (default: `500`)

--- a/apps/voice/internal/app/config_live.go
+++ b/apps/voice/internal/app/config_live.go
@@ -87,9 +87,9 @@ func applyConfigPatch(base SidecarConfig, patch *ConfigPatch) (SidecarConfig, er
 	}
 
 	if patch.SttCommitResponseTimeoutMs != nil {
-		if *patch.SttCommitResponseTimeoutMs < 0 || *patch.SttCommitResponseTimeoutMs > 120000 {
+		if *patch.SttCommitResponseTimeoutMs < 0 || *patch.SttCommitResponseTimeoutMs > 180_000 {
 			return SidecarConfig{}, fmt.Errorf(
-				"sttCommitResponseTimeoutMs must be within [0, 120000]",
+				"sttCommitResponseTimeoutMs must be within [0, 180000]",
 			)
 		}
 		out.SttCommitResponseTimeoutMs = *patch.SttCommitResponseTimeoutMs
@@ -113,4 +113,3 @@ func applyConfigPatch(base SidecarConfig, patch *ConfigPatch) (SidecarConfig, er
 
 	return out, nil
 }
-

--- a/apps/voice/internal/app/transcribe.go
+++ b/apps/voice/internal/app/transcribe.go
@@ -14,6 +14,23 @@ import (
 
 const audioMeterEmitInterval = 40 * time.Millisecond
 
+func sttInactivityTimeoutSecondsFromCommitTimeoutMS(timeoutMS int) int {
+	if timeoutMS <= 0 {
+		return 0
+	}
+	sec := timeoutMS / 1000
+	if timeoutMS%1000 != 0 {
+		sec++
+	}
+	if sec < 1 {
+		sec = 1
+	}
+	if sec > 180 {
+		sec = 180
+	}
+	return sec
+}
+
 func normalizeMeterRMS(rms float64) float64 {
 	if rms <= 0 {
 		return 0
@@ -34,7 +51,14 @@ func (a *App) transcribeLoop(ctx context.Context, apiKey string, rec *mic.Record
 
 	cfg := a.getSidecarConfig()
 
-	client, err := stt.NewElevenLabsStreamingClient(ctx, apiKey, cfg.SttModelId, 16000, cfg.SttLanguageCode)
+	client, err := stt.NewElevenLabsStreamingClient(
+		ctx,
+		apiKey,
+		cfg.SttModelId,
+		16000,
+		cfg.SttLanguageCode,
+		sttInactivityTimeoutSecondsFromCommitTimeoutMS(cfg.SttCommitResponseTimeoutMs),
+	)
 	if err != nil {
 		_ = a.write(Event{Type: "error", Message: fmt.Sprintf("failed to start elevenlabs streaming stt: %v", err)})
 		return
@@ -102,7 +126,7 @@ func (a *App) transcribeLoop(ctx context.Context, apiKey string, rec *mic.Record
 
 		// Apply any pending live config updates before draining STT events.
 		reload := false
-		drainUpdates:
+	drainUpdates:
 		for {
 			select {
 			case <-a.cfgUpdateCh:
@@ -118,7 +142,9 @@ func (a *App) transcribeLoop(ctx context.Context, apiKey string, rec *mic.Record
 			// Always refresh the commit timeout: it only matters for future commit holds.
 			commitResponseTimeoutMS = newCfg.SttCommitResponseTimeoutMs
 
-			sttChanged := newCfg.SttModelId != prevCfg.SttModelId || newCfg.SttLanguageCode != prevCfg.SttLanguageCode
+			sttChanged := newCfg.SttModelId != prevCfg.SttModelId ||
+				newCfg.SttLanguageCode != prevCfg.SttLanguageCode ||
+				newCfg.SttCommitResponseTimeoutMs != prevCfg.SttCommitResponseTimeoutMs
 			vadChanged :=
 				newCfg.VadDebugEnabled != prevCfg.VadDebugEnabled ||
 					newCfg.VadThresholdMultiplier != prevCfg.VadThresholdMultiplier ||
@@ -133,7 +159,14 @@ func (a *App) transcribeLoop(ctx context.Context, apiKey string, rec *mic.Record
 			if sttChanged {
 				// Close the websocket so we don't keep draining a client that no longer matches tuning.
 				_ = client.Close()
-				client, err = stt.NewElevenLabsStreamingClient(ctx, apiKey, newCfg.SttModelId, 16000, newCfg.SttLanguageCode)
+				client, err = stt.NewElevenLabsStreamingClient(
+					ctx,
+					apiKey,
+					newCfg.SttModelId,
+					16000,
+					newCfg.SttLanguageCode,
+					sttInactivityTimeoutSecondsFromCommitTimeoutMS(newCfg.SttCommitResponseTimeoutMs),
+				)
 				if err != nil {
 					_ = a.write(Event{Type: "error", Message: fmt.Sprintf("failed to reconnect elevenlabs streaming stt: %v", err)})
 					return

--- a/apps/voice/internal/app/transcribe_test.go
+++ b/apps/voice/internal/app/transcribe_test.go
@@ -1,0 +1,28 @@
+package app
+
+import "testing"
+
+func TestSttInactivityTimeoutSecondsFromCommitTimeoutMS(t *testing.T) {
+	tests := []struct {
+		name    string
+		inMS    int
+		wantSec int
+	}{
+		{name: "off when non positive", inMS: 0, wantSec: 0},
+		{name: "off when negative", inMS: -100, wantSec: 0},
+		{name: "round up to one second", inMS: 1, wantSec: 1},
+		{name: "round up partial second", inMS: 1500, wantSec: 2},
+		{name: "exact second", inMS: 5000, wantSec: 5},
+		{name: "180s config maps directly", inMS: 180_000, wantSec: 180},
+		{name: "clamp to max", inMS: 999_999, wantSec: 180},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := sttInactivityTimeoutSecondsFromCommitTimeoutMS(tc.inMS)
+			if got != tc.wantSec {
+				t.Fatalf("got %d, want %d", got, tc.wantSec)
+			}
+		})
+	}
+}

--- a/apps/voice/internal/stt/elevenlabs_stream.go
+++ b/apps/voice/internal/stt/elevenlabs_stream.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -42,7 +43,14 @@ type ElevenLabsStreamingClient struct {
 	pendingUncommittedBytes int
 }
 
-func NewElevenLabsStreamingClient(ctx context.Context, apiKey string, modelID string, sampleRate int, languageCode string) (*ElevenLabsStreamingClient, error) {
+func NewElevenLabsStreamingClient(
+	ctx context.Context,
+	apiKey string,
+	modelID string,
+	sampleRate int,
+	languageCode string,
+	inactivityTimeoutSeconds int,
+) (*ElevenLabsStreamingClient, error) {
 	if strings.TrimSpace(apiKey) == "" {
 		return nil, fmt.Errorf("ELEVENLABS_API_KEY is empty")
 	}
@@ -65,6 +73,12 @@ func NewElevenLabsStreamingClient(ctx context.Context, apiKey string, modelID st
 	query.Set("audio_format", "pcm_16000")
 	if lc := strings.TrimSpace(languageCode); lc != "" {
 		query.Set("language_code", lc)
+	}
+	if inactivityTimeoutSeconds > 0 {
+		if inactivityTimeoutSeconds > 180 {
+			inactivityTimeoutSeconds = 180
+		}
+		query.Set("inactivity_timeout", strconv.Itoa(inactivityTimeoutSeconds))
 	}
 	for _, kt := range AllRealtimeSTTKeyterms() {
 		kt = strings.TrimSpace(kt)

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -83,7 +83,7 @@
         "vocode.voiceSttCommitResponseTimeoutMs": {
           "type": "number",
           "default": 5000,
-          "description": "After commit:true, flush deferred PCM if committed_transcript never arrives (ms). 0 = wait indefinitely."
+          "description": "After commit:true, flush deferred PCM if committed_transcript never arrives (ms, max 180000 / 180s). Also mapped to ElevenLabs realtime inactivity_timeout (rounded up to seconds; provider cap applies). 0 = disabled for both behaviors."
         },
         "vocode.voiceVadThresholdMultiplier": {
           "type": "number",

--- a/apps/vscode-extension/webview/panels/settings/settings-widgets.tsx
+++ b/apps/vscode-extension/webview/panels/settings/settings-widgets.tsx
@@ -56,7 +56,7 @@ export const SLIDER_SPECS: Record<
   daemonVoiceTranscriptMaxMergeJobs: { min: 1, max: 20, step: 1 },
   daemonVoiceTranscriptMaxMergeChars: { min: 500, max: 50_000, step: 100 },
   sessionIdleResetMs: { min: 60_000, max: 14_400_000, step: 60_000 },
-  voiceSttCommitResponseTimeoutMs: { min: 1000, max: 120_000, step: 500 },
+  voiceSttCommitResponseTimeoutMs: { min: 1000, max: 180_000, step: 500 },
 };
 
 function clamp(n: number, min: number, max: number): number {


### PR DESCRIPTION
### Motivation

- Align the sidecar's STT commit-hold timeout with the ElevenLabs realtime `inactivity_timeout` so the provider and local commit behavior stay consistent.  
- Increase the allowed commit timeout ceiling to 180000 ms (180s) to match ElevenLabs' cap.  
- Expose and document the updated behavior in the VS Code settings and README.

### Description

- Added `sttInactivityTimeoutSecondsFromCommitTimeoutMS` to convert/round `SttCommitResponseTimeoutMs` (ms) to seconds and clamp to `[0, 180]`.  
- Passed the converted `inactivity_timeout` seconds to the ElevenLabs realtime websocket via `NewElevenLabsStreamingClient` and added an `inactivityTimeoutSeconds` parameter to that constructor.  
- Bound the query `inactivity_timeout` to `180` seconds inside `elevenlabs_stream.go` and only set it when non-zero.  
- Increased the server-side validation ceiling for `sttCommitResponseTimeoutMs` from `120000` to `180000` in `applyConfigPatch`.  
- Updated live reconnection logic to treat changes to `SttCommitResponseTimeoutMs` as a reason to recreate the STT client so the new inactivity timeout is applied.  
- Added unit test `TestSttInactivityTimeoutSecondsFromCommitTimeoutMS` in `transcribe_test.go`.  
- Updated documentation and UI: added README mention for `VOCODE_VOICE_STT_COMMIT_RESPONSE_TIMEOUT_MS`, clarified description in `package.json`, and raised the VS Code slider max for `voiceSttCommitResponseTimeoutMs` to `180000` in `settings-widgets.tsx`.

### Testing

- Ran the unit test `TestSttInactivityTimeoutSecondsFromCommitTimeoutMS` with `go test ./apps/voice/internal/app -run TestSttInactivityTimeoutSecondsFromCommitTimeoutMS -v` and it passed.  
- Verified compilation of modified packages by running `go test ./...` locally, and tests completed successfully for the updated packages.