### PR TITLE
voice: decouple ElevenLabs inactivity_timeout from STT commit timeout

### DIFF
--- a/apps/voice/internal/app/transcribe.go
+++ b/apps/voice/internal/app/transcribe.go
@@ -14,22 +14,6 @@ import (
 
 const audioMeterEmitInterval = 40 * time.Millisecond
 
-func sttInactivityTimeoutSecondsFromCommitTimeoutMS(timeoutMS int) int {
-	if timeoutMS <= 0 {
-		return 0
-	}
-	sec := timeoutMS / 1000
-	if timeoutMS%1000 != 0 {
-		sec++
-	}
-	if sec < 1 {
-		sec = 1
-	}
-	if sec > 180 {
-		sec = 180
-	}
-	return sec
-}
 
 func normalizeMeterRMS(rms float64) float64 {
 	if rms <= 0 {
@@ -57,7 +41,6 @@ func (a *App) transcribeLoop(ctx context.Context, apiKey string, rec *mic.Record
 		cfg.SttModelId,
 		16000,
 		cfg.SttLanguageCode,
-		sttInactivityTimeoutSecondsFromCommitTimeoutMS(cfg.SttCommitResponseTimeoutMs),
 	)
 	if err != nil {
 		_ = a.write(Event{Type: "error", Message: fmt.Sprintf("failed to start elevenlabs streaming stt: %v", err)})
@@ -165,7 +148,6 @@ func (a *App) transcribeLoop(ctx context.Context, apiKey string, rec *mic.Record
 					newCfg.SttModelId,
 					16000,
 					newCfg.SttLanguageCode,
-					sttInactivityTimeoutSecondsFromCommitTimeoutMS(newCfg.SttCommitResponseTimeoutMs),
 				)
 				if err != nil {
 					_ = a.write(Event{Type: "error", Message: fmt.Sprintf("failed to reconnect elevenlabs streaming stt: %v", err)})

--- a/apps/voice/internal/stt/elevenlabs_stream.go
+++ b/apps/voice/internal/stt/elevenlabs_stream.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -49,7 +48,6 @@ func NewElevenLabsStreamingClient(
 	modelID string,
 	sampleRate int,
 	languageCode string,
-	inactivityTimeoutSeconds int,
 ) (*ElevenLabsStreamingClient, error) {
 	if strings.TrimSpace(apiKey) == "" {
 		return nil, fmt.Errorf("ELEVENLABS_API_KEY is empty")
@@ -73,12 +71,6 @@ func NewElevenLabsStreamingClient(
 	query.Set("audio_format", "pcm_16000")
 	if lc := strings.TrimSpace(languageCode); lc != "" {
 		query.Set("language_code", lc)
-	}
-	if inactivityTimeoutSeconds > 0 {
-		if inactivityTimeoutSeconds > 180 {
-			inactivityTimeoutSeconds = 180
-		}
-		query.Set("inactivity_timeout", strconv.Itoa(inactivityTimeoutSeconds))
 	}
 	for _, kt := range AllRealtimeSTTKeyterms() {
 		kt = strings.TrimSpace(kt)

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -83,7 +83,7 @@
         "vocode.voiceSttCommitResponseTimeoutMs": {
           "type": "number",
           "default": 5000,
-          "description": "After commit:true, flush deferred PCM if committed_transcript never arrives (ms, max 180000 / 180s). Also mapped to ElevenLabs realtime inactivity_timeout (rounded up to seconds; provider cap applies). 0 = disabled for both behaviors."
+          "description": "After commit:true, flush deferred PCM if committed_transcript never arrives (ms). 0 = disabled."
         },
         "vocode.voiceVadThresholdMultiplier": {
           "type": "number",


### PR DESCRIPTION
The STT commit response timeout (default 5s) was being passed as inactivity_timeout to the ElevenLabs WebSocket URL, causing the connection to be closed by the provider after ~5s of silence. This resulted in repeated "websocket: close sent" errors and quota_exceeded errors from too many reconnecting sessions.

These are two different concerns: the local commit flush timeout has no bearing on how long the provider should keep the WS alive. Remove the inactivity_timeout parameter entirely and let ElevenLabs use its own default connection lifetime.